### PR TITLE
[FEATURE] Estimate gas used for scheduling.

### DIFF
--- a/common/components/TXMetaDataPanel/components/AdvancedGas.tsx
+++ b/common/components/TXMetaDataPanel/components/AdvancedGas.tsx
@@ -158,13 +158,13 @@ class AdvancedGas extends React.Component<Props, State> {
     );
   }
 
-  private getScheduleFeeFormula({ gasPriceWei, scheduleGasLimit, fee, usd }: RenderData) {
+  private getScheduleFeeFormula({ gasLimit, gasPriceWei, scheduleGasLimit, fee, usd }: RenderData) {
     const { scheduleGasPrice, timeBounty } = this.props;
 
     return (
       <div>
         {timeBounty && timeBounty.value && timeBounty.value.toString()} + {gasPriceWei} *{' '}
-        {EAC_SCHEDULING_CONFIG.SCHEDULING_GAS_LIMIT.toString()} +{' '}
+        {gasLimit.toString()} +{' '}
         {scheduleGasPrice && scheduleGasPrice.value && scheduleGasPrice.value.toString()} * ({EAC_SCHEDULING_CONFIG.FUTURE_EXECUTION_COST.toString()}{' '}
         + {scheduleGasLimit}) =&nbsp;{fee}&nbsp;{usd && <span>~=&nbsp;${usd}&nbsp;USD</span>}
       </div>

--- a/common/components/TXMetaDataPanel/components/FeeSummary.tsx
+++ b/common/components/TXMetaDataPanel/components/FeeSummary.tsx
@@ -127,7 +127,7 @@ class FeeSummary extends React.Component<Props> {
   }
 
   private calculateSchedulingFee() {
-    const { gasPrice, scheduleGasLimit, scheduleGasPrice, timeBounty } = this.props;
+    const { gasLimit, gasPrice, scheduleGasLimit, scheduleGasPrice, timeBounty } = this.props;
 
     return (
       gasPrice.value &&
@@ -137,7 +137,8 @@ class FeeSummary extends React.Component<Props> {
         scheduleGasLimit.value,
         gasPrice.value,
         scheduleGasPrice.value,
-        timeBounty.value
+        timeBounty.value,
+        gasLimit.value
       )
     );
   }

--- a/common/features/schedule/actions.ts
+++ b/common/features/schedule/actions.ts
@@ -157,3 +157,28 @@ export const setCurrentWindowStart = (
   payload
 });
 //#endregion Window Size
+
+//#region Estimate Scheduling Gas
+export type TEstimateSchedulingGasRequested = typeof estimateSchedulingGasRequested;
+export const estimateSchedulingGasRequested = (
+  payload: types.EstimateSchedulingGasRequestedAction['payload']
+): types.EstimateSchedulingGasRequestedAction => ({
+  type: types.ScheduleActions.ESTIMATE_SCHEDULING_GAS_REQUESTED,
+  payload
+});
+
+export type TEstimateSchedulingGasSucceeded = typeof estimateSchedulingGasSucceeded;
+export const estimateSchedulingGasSucceeded = (): types.EstimateSchedulingGasSucceededAction => ({
+  type: types.ScheduleActions.ESTIMATE_SCHEDULING_GAS_SUCCEEDED
+});
+
+export type TEstimateSchedulingGasFailed = typeof estimateSchedulingGasFailed;
+export const estimateSchedulingGasFailed = (): types.EstimateSchedulingGasFailedAction => ({
+  type: types.ScheduleActions.ESTIMATE_SCHEDULING_GAS_FAILED
+});
+
+export type TEstimateSchedulingGasTimedout = typeof estimateSchedulingGasTimedout;
+export const estimateSchedulingGasTimedout = (): types.EstimateSchedulingGasTimeoutAction => ({
+  type: types.ScheduleActions.ESTIMATE_SCHEDULING_GAS_TIMEDOUT
+});
+//#endregion Estimate Scheduling Gas

--- a/common/features/schedule/types.ts
+++ b/common/features/schedule/types.ts
@@ -1,4 +1,5 @@
 import { Wei } from 'libs/units';
+import { IHexStrTransaction } from 'libs/transaction';
 
 export interface ScheduleState {
   schedulingToggle: SetSchedulingToggleAction['payload'];
@@ -32,7 +33,11 @@ export enum ScheduleActions {
   TYPE_SET = 'SCHEDULE_TYPE_SET',
   TOGGLE_SET = 'SCHEDULING_TOGGLE_SET',
   DEPOSIT_FIELD_SET = 'SCHEDULE_DEPOSIT_FIELD_SET',
-  PARAMS_VALIDITY_SET = 'SCHEDULE_PARAMS_VALIDITY_SET'
+  PARAMS_VALIDITY_SET = 'SCHEDULE_PARAMS_VALIDITY_SET',
+  ESTIMATE_SCHEDULING_GAS_REQUESTED = 'ESTIMATE_SCHEDULING_GAS_REQUESTED',
+  ESTIMATE_SCHEDULING_GAS_SUCCEEDED = 'ESTIMATE_SCHEDULING_GAS_SUCCEEDED',
+  ESTIMATE_SCHEDULING_GAS_FAILED = 'ESTIMATE_SCHEDULING_GAS_FAILED',
+  ESTIMATE_SCHEDULING_GAS_TIMEDOUT = 'ESTIMATE_SCHEDULING_GAS_TIMEDOUT'
 }
 
 //#region Fields
@@ -194,5 +199,24 @@ export interface SetCurrentWindowStartAction {
 
 export type WindowStartCurrentAction = SetCurrentWindowStartAction;
 //#endregion Window Size
+
+//#region Estimate Scheduling Gas
+export interface EstimateSchedulingGasRequestedAction {
+  type: ScheduleActions.ESTIMATE_SCHEDULING_GAS_REQUESTED;
+  payload: Partial<IHexStrTransaction>;
+}
+
+export interface EstimateSchedulingGasSucceededAction {
+  type: ScheduleActions.ESTIMATE_SCHEDULING_GAS_SUCCEEDED;
+}
+
+export interface EstimateSchedulingGasFailedAction {
+  type: ScheduleActions.ESTIMATE_SCHEDULING_GAS_FAILED;
+}
+
+export interface EstimateSchedulingGasTimeoutAction {
+  type: ScheduleActions.ESTIMATE_SCHEDULING_GAS_TIMEDOUT;
+}
+//#endregion Estimate Scheduling Gas
 
 export type ScheduleAction = ScheduleFieldAction;

--- a/common/features/selectors.ts
+++ b/common/features/selectors.ts
@@ -262,6 +262,7 @@ export const getSchedulingTransaction = (state: AppState): IGetTransaction => {
   const scheduleGasPrice = scheduleSelectors.getScheduleGasPrice(state);
   const scheduleGasLimit = scheduleSelectors.getScheduleGasLimit(state);
   const scheduleType = scheduleSelectors.getScheduleType(state);
+  const gasLimit = transactionFieldsSelectors.getGasLimit(state);
 
   const endowment = calcEACEndowment(
     scheduleGasLimit.value,
@@ -303,7 +304,7 @@ export const getSchedulingTransaction = (state: AppState): IGetTransaction => {
   const transactionOptions = {
     to: getSchedulerAddress(scheduleType.value, configSelectors.getNetworkConfig(state)),
     data: transactionData,
-    gasLimit: EAC_SCHEDULING_CONFIG.SCHEDULING_GAS_LIMIT,
+    gasLimit: gasLimit.value || new BN('0'),
     gasPrice: gasPrice.value,
     nonce: Nonce('0'),
     value: endowment

--- a/common/features/transaction/network/sagas.spec.ts
+++ b/common/features/transaction/network/sagas.spec.ts
@@ -18,7 +18,7 @@ import { makeTransaction, getTransactionFields } from 'libs/transaction';
 import * as derivedSelectors from 'features/selectors';
 import { configMetaTypes, configMetaSelectors, configNodesSelectors } from 'features/config';
 import { walletTypes, walletSelectors } from 'features/wallet';
-import { scheduleActions, scheduleSelectors } from 'features/schedule';
+import { scheduleSelectors } from 'features/schedule';
 import { notificationsActions } from 'features/notifications';
 import { transactionFieldsTypes, transactionFieldsActions } from '../fields';
 import * as transactionTypes from '../types';

--- a/common/features/transaction/network/sagas.spec.ts
+++ b/common/features/transaction/network/sagas.spec.ts
@@ -247,25 +247,10 @@ describe('Network Sagas', () => {
         );
       });
 
-      it('should select isSchedulingEnabled', () => {
+      it('should put setGasLimitField', () => {
         gens.timeOutCase = gens.successCase.clone();
         expect(gens.successCase.next(successfulGasEstimationResult).value).toEqual(
-          select(scheduleSelectors.isSchedulingEnabled)
-        );
-      });
-
-      it('should put setGasLimitField', () => {
-        gens.scheduleCase = gens.successCase.clone();
-        const notScheduling = null as any;
-        expect(gens.successCase.next(notScheduling).value).toEqual(
           put(transactionFieldsActions.setGasLimitField(gasSetOptions))
-        );
-      });
-
-      it('should put setScheduleGasLimitField', () => {
-        const scheduling = { value: true } as any;
-        expect(gens.scheduleCase.next(scheduling).value).toEqual(
-          put(scheduleActions.setScheduleGasLimitField(gasSetOptions))
         );
       });
 

--- a/common/features/transaction/network/sagas.spec.ts
+++ b/common/features/transaction/network/sagas.spec.ts
@@ -141,8 +141,14 @@ describe('Network Sagas', () => {
         expect(gen.next(tx).value).toEqual(call(getTransactionFields, transaction));
       });
 
+      it('should select isSchedulingEnabled', () => {
+        expect(gen.next(transactionFields).value).toEqual(
+          select(scheduleSelectors.isSchedulingEnabled)
+        );
+      });
+
       it('should put estimatedGasRequested with rest', () => {
-        expect(gen.next(transactionFields).value).toEqual(put(actions.estimateGasRequested(rest)));
+        expect(gen.next(false).value).toEqual(put(actions.estimateGasRequested(rest)));
       });
     });
 

--- a/common/features/transaction/network/sagas.ts
+++ b/common/features/transaction/network/sagas.ts
@@ -115,7 +115,13 @@ export function* shouldEstimateGas(): SagaIterator {
       rest.to = undefined as any;
     }
 
-    yield put(actions.estimateGasRequested(rest));
+    const scheduling: boolean = yield select(scheduleSelectors.isSchedulingEnabled);
+
+    if (scheduling) {
+      yield put(scheduleActions.estimateSchedulingGasRequested(rest));
+    } else {
+      yield put(actions.estimateGasRequested(rest));
+    }
   }
 }
 
@@ -152,13 +158,7 @@ export function* estimateGas(): SagaIterator {
           value: gasLimit
         };
 
-        const scheduling: boolean = yield select(scheduleSelectors.isSchedulingEnabled);
-
-        if (scheduling) {
-          yield put(scheduleActions.setScheduleGasLimitField(gasSetOptions));
-        } else {
-          yield put(transactionFieldsActions.setGasLimitField(gasSetOptions));
-        }
+        yield put(transactionFieldsActions.setGasLimitField(gasSetOptions));
 
         yield put(actions.estimateGasSucceeded());
       } else {

--- a/common/libs/scheduling/index.ts
+++ b/common/libs/scheduling/index.ts
@@ -99,13 +99,14 @@ export const calcEACTotalCost = (
   callGas: Wei,
   gasPrice: Wei,
   callGasPrice: Wei | null,
-  timeBounty: Wei | null
+  timeBounty: Wei | null,
+  gasLimit: Wei | null
 ) => {
   if (!callGasPrice) {
     callGasPrice = gasPriceToBase(EAC_SCHEDULING_CONFIG.SCHEDULE_GAS_PRICE_FALLBACK);
   }
 
-  const deployCost = gasPrice.mul(EAC_SCHEDULING_CONFIG.SCHEDULING_GAS_LIMIT);
+  const deployCost = gasPrice.mul(gasLimit || new BN('0'));
 
   const futureExecutionCost = calcEACFutureExecutionCost(callGas, callGasPrice, timeBounty);
 


### PR DESCRIPTION
### Description

Removes fixed gas price for scheduling (1 500 000). Instead estimates gas.

### Changes

- Remove fixed 1 500 000 price for scheduling, estimate it instead

### Steps to Test

1. Toggle 'Send Later'
2. Prepare transaction to schedule
3. Look at gas limit in Advanced section - it should be calculated dynamically

### Video

https://youtu.be/DXmjrkbPYwg